### PR TITLE
Add Android example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Ignore Gradle build output directory
 build
 gradle/wrapper/gradle-wrapper.jar
+.kotlin

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("com.android.application") version "8.4.1"
+    id("org.jetbrains.kotlin.android") version "2.1.20"
+}
+
+android {
+    namespace = "com.example.androidcalc"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.androidcalc"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+    kotlin {
+        jvmToolchain(21)
+    }
+}
+
+dependencies {
+    implementation(project(":lib"))
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.12.0")
+}

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.androidcalc">
+    <application
+        android:label="Calculator"
+        android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/androidApp/src/main/java/com/example/androidcalc/MainActivity.kt
+++ b/androidApp/src/main/java/com/example/androidcalc/MainActivity.kt
@@ -1,0 +1,17 @@
+package com.example.androidcalc
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.TextView
+import com.example.calc.Calculator
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val calc = Calculator()
+        val result = calc.add(2.0, 3.0)
+        findViewById<TextView>(R.id.resultText).text = "2 + 3 = $result"
+    }
+}

--- a/androidApp/src/main/res/layout/activity_main.xml
+++ b/androidApp/src/main/res/layout/activity_main.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <TextView
+        android:id="@+id/resultText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Result" />
+</LinearLayout>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Calculator</string>
+</resources>

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,3 @@
+<resources>
+    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+</resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
 
 org.gradle.configuration-cache=true
+org.gradle.java.installations.auto-download=false
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,10 +10,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
 }
 
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 kotlin {
     jvm()
@@ -21,6 +17,8 @@ kotlin {
         browser()
         nodejs()
     }
+
+    jvmToolchain(21)
 
     sourceSets {
         val commonMain by getting {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,10 +5,29 @@
  * For more detailed information on multi-project builds, please refer to https://docs.gradle.org/8.14/userguide/multi_project_builds.html in the Gradle documentation.
  */
 
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }
 
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "calc-kmp"
 include("lib")
+include("androidApp")


### PR DESCRIPTION
## Summary
- create Android `androidApp` module with simple screen
- allow Gradle to use existing JDK without downloads
- add repositories and plugin management to settings
- update library to use JDK 21
- ignore build artifacts

## Testing
- `./gradlew tasks --all`
- `./gradlew jvmTest`


------
https://chatgpt.com/codex/tasks/task_e_6846f66b1b8c832c983507918e564465