### PR TITLE
Fix crash due to missing GridLayout

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.gridlayout:gridlayout:1.0.0")
 }


### PR DESCRIPTION
## Summary
- add dependency on `androidx.gridlayout:gridlayout`

## Testing
- `gradle wrapper`
- `./gradlew jvmTest --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68487caa8600832c867b080e7efb4074