### PR TITLE
Fix missing ConstraintLayout dependency

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -29,5 +29,6 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.gridlayout:gridlayout:1.0.0")
 }


### PR DESCRIPTION
## Summary
- include `androidx.constraintlayout` so the layout can inflate

## Testing
- `./gradlew jvmTest`

------
https://chatgpt.com/codex/tasks/task_e_684980205af8832cbbd4d8b9a2d878c4